### PR TITLE
update gitignore for development files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,15 @@
 .DS_store
+._*
+Thumbs.db
+Desktop.ini
+
+# Project files
 ino_project
+
+# Closure library needed for uncompressed development
+/closure-library
+/closure-library-read-only
+
+# Python byte-compiled / optimized
+__pycache__/
+*.py[cod]


### PR DESCRIPTION
Adds useful gitignore entries for development with Blocklyduino: the closure library and python bytecode from the build files (and also general OS files).